### PR TITLE
Experiment with stricter and more helpful types

### DIFF
--- a/src/apis/onMessage.ts
+++ b/src/apis/onMessage.ts
@@ -1,13 +1,11 @@
-import { JsonValue } from 'type-fest'
 import { GetDataType, GetReturnType, OnMessageCallback, DataTypeKey } from '../types'
 import { onMessageListeners } from '../internal'
 
 export function onMessage<
-  Data extends JsonValue,
-  K extends DataTypeKey | string
+  K extends DataTypeKey,
 >(
   messageID: K,
-  callback: OnMessageCallback<GetDataType<K, Data>, GetReturnType<K, any>>,
+  callback: OnMessageCallback<GetDataType<K>, GetReturnType<K>>,
 ): void {
   onMessageListeners.set(messageID, callback)
 }

--- a/src/apis/sendMessage.ts
+++ b/src/apis/sendMessage.ts
@@ -16,11 +16,10 @@ import { parseEndpoint } from '../utils'
  * @param destination default 'background'
  */
 export async function sendMessage<
-  ReturnType extends JsonValue,
-  K extends DataTypeKey | string
+  K extends DataTypeKey,
 >(
   messageID: K,
-  data: GetDataType<K, JsonValue>,
+  data: GetDataType<K>,
   destination: Destination = 'background',
 ) {
   const endpoint = typeof destination === 'string' ? parseEndpoint(destination) : destination
@@ -35,7 +34,7 @@ export async function sendMessage<
       throw new TypeError(`${errFn} When sending messages from background page, use @tabId syntax to target specific tab`)
   }
 
-  return new Promise<GetReturnType<K, ReturnType>>((resolve, reject) => {
+  return new Promise<GetReturnType<K>>((resolve, reject) => {
     const payload: IInternalMessage = {
       messageID,
       data,

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -14,7 +14,7 @@ const openStreams = new Map<string, Stream>()
 const onOpenStreamCallbacks = new Map<string, (stream: Stream) => void>()
 const streamyEmitter = createNanoEvents()
 
-onMessage<{ channel: string; streamId: string }, string>('__crx_bridge_stream_open__', (message) => {
+onMessage('__crx_bridge_stream_open__', (message) => {
   return new Promise((resolve) => {
     const { sender, data } = message
     const { channel } = data

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -17,8 +17,8 @@ export const context: RuntimeContext
         : null
 
 const runtimeId: string = uuid()
-export const openTransactions = new Map<string, { resolve: (v: void | JsonValue | PromiseLike<JsonValue>) => void; reject: (e: JsonValue) => void }>()
-export const onMessageListeners = new Map<string, OnMessageCallback<JsonValue>>()
+export const openTransactions = new Map<string, { resolve: (v: unknown) => void; reject: (e: unknown) => void }>()
+export const onMessageListeners = new Map<string, OnMessageCallback<unknown, unknown>>()
 const messageQueue = new Set<IQueuedMessage>()
 const portMap = new Map<string, Runtime.Port>()
 
@@ -240,7 +240,7 @@ async function handleInboundMessage(message: IInternalMessage) {
   }
 
   const handleNewMessage = async() => {
-    let reply: JsonValue | void
+    let reply: unknown
     let err: Error
     let noHandlerFoundError = false
 

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -25,7 +25,7 @@ class Stream {
     this.isClosed = false
 
     if (!Stream.initDone) {
-      onMessage<{ streamId: string; action: 'transfer' | 'close'; streamTransfer: JsonValue }, string>('__crx_bridge_stream_transfer__', (msg) => {
+      onMessage('__crx_bridge_stream_transfer__', (msg) => {
         const { streamId, streamTransfer, action } = msg.data
         const stream = Stream.openStreams.get(streamId)
         if (stream && !stream.isClosed) {


### PR DESCRIPTION
requested experiment by @zikaari, [here](https://github.com/antfu/webext-bridge/pull/24#issuecomment-1169411905)
fixes https://github.com/antfu/webext-bridge/issues/21

## Improvements

### Safety against typos
<img width="836" alt="Screenshot 2022-06-30 at 11 32 38" src="https://user-images.githubusercontent.com/9800850/176646545-e780ed6c-0632-4eb0-bf68-e9d61f2d22c7.png">

### Autocomplete
<img width="585" alt="Screenshot 2022-06-30 at 11 32 15" src="https://user-images.githubusercontent.com/9800850/176646228-5b47e6dc-5014-40bc-97d0-deadbbe89244.png">

## Breaking change

This requires one to extend the `ProtocolMap` in their project and removes the ability to pass generics related to data and return types on per-method basis. If one is not interested in type-safety and they just want to accept anything then they can opt-out of the `ProtocolMap` like this:
```ts
interface ProtocolMap {
  [k: string]: any;
}
```

