### PR TITLE
Reliable and safer messaging

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,87 +1,328 @@
 import browser from 'webextension-polyfill'
 import type { Runtime } from 'webextension-polyfill'
-import type { IInternalMessage } from './types'
 import { createEndpointRuntime } from './internal/endpoint-runtime'
 import { formatEndpoint, parseEndpoint } from './internal/endpoint'
 import { createStreamWirings } from './internal/stream'
+import type { EndpointFingerprint } from './internal/endpoint-fingerprint'
+import { createFingerprint } from './internal/endpoint-fingerprint'
+import { decodeConnectionArgs } from './internal/connection-args'
+import type { DeliveryReceipt } from './internal/delivery-logger'
+import { createDeliveryLogger } from './internal/delivery-logger'
+import type { RequestMessage } from './internal/port-message'
+import { PortMessage } from './internal/port-message'
+import type { InternalMessage } from './types'
 
-interface IQueuedMessage {
-  resolvedDestination: string
-  message: IInternalMessage
+interface PortConnection {
+  port: Runtime.Port
+  fingerprint: EndpointFingerprint
 }
 
-const messageQueue = new Set<IQueuedMessage>()
-const portMap = new Map<string, Runtime.Port>()
+const pendingResponses = createDeliveryLogger()
+const connMap = new Map<string, PortConnection>()
+const oncePortConnectedCbs = new Map<string, Set<() => void>>()
+const onceSessionEndCbs = new Map<EndpointFingerprint, Set<() => void>>()
+
+const oncePortConnected = (endpointName: string, cb: () => void) => {
+  oncePortConnectedCbs.set(
+    endpointName,
+    (oncePortConnectedCbs.get(endpointName) || new Set()).add(cb),
+  )
+
+  return () => {
+    const su = oncePortConnectedCbs.get(endpointName)
+    if (su?.delete(cb) && su?.size === 0)
+      oncePortConnectedCbs.delete(endpointName)
+  }
+}
+
+const onceSessionEnded = (
+  sessionFingerprint: EndpointFingerprint,
+  cb: () => void,
+) => {
+  onceSessionEndCbs.set(
+    sessionFingerprint,
+    (onceSessionEndCbs.get(sessionFingerprint) || new Set()).add(cb),
+  )
+}
+
+const notifyEndpoint = (endpoint: string) => ({
+  withFingerprint: (fingerprint: EndpointFingerprint) => {
+    const nextChain = <T>(v: T) => ({ and: () => v })
+
+    const notifications = {
+      aboutIncomingMessage: (message: InternalMessage) => {
+        const recipient = connMap.get(endpoint)
+
+        PortMessage.toExtensionContext(recipient.port, {
+          status: 'incoming',
+          message,
+        })
+
+        return nextChain(notifications)
+      },
+
+      aboutSuccessfulDelivery: (receipt: DeliveryReceipt) => {
+        const sender = connMap.get(endpoint)
+        PortMessage.toExtensionContext(sender.port, {
+          status: 'delivered',
+          receipt,
+        })
+
+        return nextChain(notifications)
+      },
+
+      aboutMessageUndeliverability: (
+        resolvedDestination: string,
+        message: InternalMessage,
+      ) => {
+        const sender = connMap.get(endpoint)
+        if (sender?.fingerprint === fingerprint) {
+          PortMessage.toExtensionContext(sender.port, {
+            status: 'undeliverable',
+            resolvedDestination,
+            message,
+          })
+        }
+
+        return nextChain(notifications)
+      },
+
+      whenDeliverableTo: (targetEndpoint: string) => {
+        const notifyDeliverability = () => {
+          const origin = connMap.get(endpoint)
+          if (
+            origin?.fingerprint === fingerprint
+            && connMap.has(targetEndpoint)
+          ) {
+            PortMessage.toExtensionContext(origin.port, {
+              status: 'deliverable',
+              deliverableTo: targetEndpoint,
+            })
+
+            return true
+          }
+        }
+
+        if (!notifyDeliverability()) {
+          const unsub = oncePortConnected(targetEndpoint, notifyDeliverability)
+          onceSessionEnded(fingerprint, unsub)
+        }
+
+        return nextChain(notifications)
+      },
+
+      aboutSessionEnded: (endedSessionFingerprint: EndpointFingerprint) => {
+        const conn = connMap.get(endpoint)
+        if (conn?.fingerprint === fingerprint) {
+          PortMessage.toExtensionContext(conn.port, {
+            status: 'terminated',
+            fingerprint: endedSessionFingerprint,
+          })
+        }
+
+        return nextChain(notifications)
+      },
+    }
+
+    return notifications
+  },
+})
+
+const sessFingerprint = createFingerprint()
 
 const endpointRuntime = createEndpointRuntime(
   'background',
   (message) => {
-    if (message.origin.context === 'background' && message.destination.context !== 'background' && !message.destination.tabId)
-      throw new TypeError('When sending messages from background page, use @tabId syntax to target specific tab')
+    if (
+      message.origin.context === 'background'
+      && message.destination.context !== 'background'
+      && !message.destination.tabId
+    ) {
+      throw new TypeError(
+        'When sending messages from background page, use @tabId syntax to target specific tab',
+      )
+    }
 
-    const { context: destName, tabId: destTabId, frameId: destFrameId } = message.destination
-    const { tabId: srcTabId } = message.origin
+    const resolvedSender = formatEndpoint({
+      ...message.origin,
+      ...(message.origin.context === 'window' && { context: 'content-script' }),
+    })
+
+    const resolvedDestination = formatEndpoint({
+      ...message.destination,
+      ...(message.destination.context === 'window' && {
+        context: 'content-script',
+      }),
+      tabId: message.destination.tabId || message.origin.tabId,
+    })
 
     // downstream endpoints are agnostic of these attributes, presence of these attrs will make them think the message is not intended for them
     message.destination.tabId = null
     message.destination.frameId = null
 
-    let resolvedDestination = ['popup', 'options'].includes(destName)
-      ? destName
-      : `${(destName === 'window' ? 'content-script' : destName)}@${(destTabId || srcTabId)}`
+    const dest = connMap.get(resolvedDestination)
+    const sender = connMap.get(resolvedSender)
 
-    // Here it is checked if a specific frame needs to receive the message
-    if (destFrameId)
-      resolvedDestination = `${resolvedDestination}.${destFrameId}`
+    const deliver = () => {
+      notifyEndpoint(resolvedDestination)
+        .withFingerprint(dest.fingerprint)
+        .aboutIncomingMessage(message)
 
-    const destPort = portMap.get(resolvedDestination)
+      const receipt: DeliveryReceipt = {
+        message,
+        to: dest.fingerprint,
+        from: {
+          endpointId: resolvedSender,
+          fingerprint: sender?.fingerprint,
+        },
+      }
 
-    if (destPort) destPort.postMessage(message)
-    else messageQueue.add({ resolvedDestination, message })
+      if (message.messageType === 'message') pendingResponses.add(receipt)
+
+      if (message.messageType === 'reply')
+        pendingResponses.remove(message.messageID)
+
+      if (sender) {
+        notifyEndpoint(resolvedSender)
+          .withFingerprint(sender.fingerprint)
+          .aboutSuccessfulDelivery(receipt)
+      }
+    }
+
+    if (dest?.port) {
+      deliver()
+    }
+    else if (message.messageType === 'message') {
+      if (message.origin.context === 'background') {
+        oncePortConnected(resolvedDestination, deliver)
+      }
+      else if (sender) {
+        notifyEndpoint(resolvedSender)
+          .withFingerprint(sender.fingerprint)
+          .aboutMessageUndeliverability(resolvedDestination, message)
+          .and()
+          .whenDeliverableTo(resolvedDestination)
+      }
+    }
+  },
+  (message) => {
+    const resolvedSender = formatEndpoint({
+      ...message.origin,
+      ...(message.origin.context === 'window' && { context: 'content-script' }),
+    })
+
+    const sender = connMap.get(resolvedSender)
+
+    const receipt: DeliveryReceipt = {
+      message,
+      to: sessFingerprint,
+      from: {
+        endpointId: resolvedSender,
+        fingerprint: sender.fingerprint,
+      },
+    }
+
+    notifyEndpoint(resolvedSender)
+      .withFingerprint(sender.fingerprint)
+      .aboutSuccessfulDelivery(receipt)
   },
 )
 
 browser.runtime.onConnect.addListener((incomingPort) => {
+  const connArgs = decodeConnectionArgs(incomingPort.name)
+
+  if (!connArgs) return
+
   // all other contexts except 'content-script' are aware of, and pass their identity as name
-  const portId = incomingPort.name || formatEndpoint({
+  connArgs.endpointName ||= formatEndpoint({
     context: 'content-script',
     tabId: incomingPort.sender.tab.id,
     frameId: incomingPort.sender.frameId,
   })
 
   // literal tab id in case of content script, however tab id of inspected page in case of devtools context
-  const { context, tabId: linkedTabId, frameId: linkedFrameId } = parseEndpoint(portId)
+  const { tabId: linkedTabId, frameId: linkedFrameId } = parseEndpoint(
+    connArgs.endpointName,
+  )
 
-  // in-case the port handshake is from something else
-  if (!linkedTabId && context !== 'popup' && context !== 'options')
-    return
+  connMap.set(connArgs.endpointName, {
+    fingerprint: connArgs.fingerprint,
+    port: incomingPort,
+  })
 
-  portMap.set(portId, incomingPort)
+  oncePortConnectedCbs.get(connArgs.endpointName)?.forEach(cb => cb())
+  oncePortConnectedCbs.delete(connArgs.endpointName)
 
-  messageQueue.forEach((queuedMsg) => {
-    if (queuedMsg.resolvedDestination === portId) {
-      incomingPort.postMessage(queuedMsg.message)
-      messageQueue.delete(queuedMsg)
-    }
+  onceSessionEnded(connArgs.fingerprint, () => {
+    const rogueMsgs = pendingResponses
+      .entries()
+      .filter(pendingMessage => pendingMessage.to === connArgs.fingerprint)
+    pendingResponses.remove(rogueMsgs)
+
+    rogueMsgs.forEach((rogueMessage) => {
+      if (rogueMessage.from.endpointId === 'background') {
+        endpointRuntime.endTransaction(rogueMessage.message.transactionId)
+      }
+      else {
+        notifyEndpoint(rogueMessage.from.endpointId)
+          .withFingerprint(rogueMessage.from.fingerprint)
+          .aboutSessionEnded(connArgs.fingerprint)
+      }
+    })
   })
 
   incomingPort.onDisconnect.addListener(() => {
     // sometimes previous content script's onDisconnect is called *after* the fresh content-script's
-    // onConnect. So without this reference equality check, we would remove the new port from map
-    if (portMap.get(portId) === incomingPort)
-      portMap.delete(portId)
+    // onConnect. So without this fingerprint equality check, we would remove the new port from map
+    if (
+      connMap.get(connArgs.endpointName)?.fingerprint === connArgs.fingerprint
+    )
+      connMap.delete(connArgs.endpointName)
+
+    onceSessionEndCbs.get(connArgs.fingerprint)?.forEach(cb => cb())
+    onceSessionEndCbs.delete(connArgs.fingerprint)
   })
 
-  incomingPort.onMessage.addListener((message: IInternalMessage) => {
-    if (message?.origin?.context) {
-      // origin tab ID is resolved from the port identifier (also prevent "MITM attacks" of extensions)
-      message.origin.tabId = linkedTabId
-      message.origin.frameId = linkedFrameId
+  incomingPort.onMessage.addListener((msg: RequestMessage) => {
+    if (msg.type === 'sync') {
+      const allActiveSessions = [...connMap.values()].map(
+        conn => conn.fingerprint,
+      )
+      const stillPending = msg.pendingResponses.filter(fp =>
+        allActiveSessions.includes(fp.to),
+      )
 
-      endpointRuntime.handleMessage(message)
+      pendingResponses.add(...stillPending)
+
+      msg.pendingResponses
+        .filter(
+          deliveryReceipt => !allActiveSessions.includes(deliveryReceipt.to),
+        )
+        .forEach(deliveryReceipt =>
+          notifyEndpoint(connArgs.endpointName)
+            .withFingerprint(connArgs.fingerprint)
+            .aboutSessionEnded(deliveryReceipt.to),
+        )
+
+      msg.pendingDeliveries.forEach(intendedDestination =>
+        notifyEndpoint(connArgs.endpointName)
+          .withFingerprint(connArgs.fingerprint)
+          .whenDeliverableTo(intendedDestination),
+      )
+
+      return
+    }
+
+    if (msg.type === 'deliver' && msg.message?.origin?.context) {
+      // origin tab ID is resolved from the port identifier (also prevent "MITM attacks" of extensions)
+      msg.message.origin.tabId = linkedTabId
+      msg.message.origin.frameId = linkedFrameId
+
+      endpointRuntime.handleMessage(msg.message)
     }
   })
 })
 
 export const { sendMessage, onMessage } = endpointRuntime
-export const { openStream, onOpenStreamChannel } = createStreamWirings(endpointRuntime)
+export const { openStream, onOpenStreamChannel }
+  = createStreamWirings(endpointRuntime)

--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -2,20 +2,16 @@ import { createEndpointRuntime } from './internal/endpoint-runtime'
 import { usePostMessaging } from './internal/post-message'
 import { createStreamWirings } from './internal/stream'
 import { createPersistentPort } from './internal/persistent-port'
+import type { InternalMessage } from './types'
 
 const win = usePostMessaging('content-script')
 const port = createPersistentPort()
-const endpointRuntime = createEndpointRuntime(
-  'content-script',
-  (message) => {
-    if (message.destination.context === 'window')
-      win.postMessage(message)
-    else
-      port.postMessage(message)
-  },
-)
+const endpointRuntime = createEndpointRuntime('content-script', (message) => {
+  if (message.destination.context === 'window') win.postMessage(message)
+  else port.postMessage(message)
+})
 
-win.onMessage((message) => {
+win.onMessage((message: InternalMessage) => {
   // a message event inside `content-script` means a script inside `window` dispatched it to be forwarded
   // so we're making sure that the origin is not tampered (i.e script is not masquerading it's true identity)
   message.origin = {
@@ -28,10 +24,24 @@ win.onMessage((message) => {
 
 port.onMessage(endpointRuntime.handleMessage)
 
+port.onFailure((message) => {
+  if (message.origin.context === 'window') {
+    win.postMessage({
+      type: 'error',
+      transactionID: message.transactionId,
+    })
+
+    return
+  }
+
+  endpointRuntime.endTransaction(message.transactionId)
+})
+
 export function allowWindowMessaging(nsps: string): void {
   win.setNamespace(nsps)
   win.enable()
 }
 
 export const { sendMessage, onMessage } = endpointRuntime
-export const { openStream, onOpenStreamChannel } = createStreamWirings(endpointRuntime)
+export const { openStream, onOpenStreamChannel }
+  = createStreamWirings(endpointRuntime)

--- a/src/internal/connection-args.ts
+++ b/src/internal/connection-args.ts
@@ -1,0 +1,31 @@
+import type { EndpointFingerprint } from './endpoint-fingerprint'
+
+export interface ConnectionArgs {
+  endpointName: string
+  fingerprint: EndpointFingerprint
+}
+
+const isValidConnectionArgs = (
+  args: unknown,
+  requiredKeys: (keyof ConnectionArgs)[] = ['endpointName', 'fingerprint'],
+): args is ConnectionArgs =>
+  typeof args === 'object'
+  && args !== null
+  && requiredKeys.every(k => k in args)
+
+export const encodeConnectionArgs = (args: ConnectionArgs) => {
+  if (!isValidConnectionArgs(args))
+    throw new TypeError('Invalid connection args')
+
+  return JSON.stringify(args)
+}
+
+export const decodeConnectionArgs = (encodedArgs: string): ConnectionArgs => {
+  try {
+    const args = JSON.parse(encodedArgs)
+    return isValidConnectionArgs(args) ? args : null
+  }
+  catch (error) {
+    return null
+  }
+}

--- a/src/internal/delivery-logger.ts
+++ b/src/internal/delivery-logger.ts
@@ -1,0 +1,28 @@
+import type { InternalMessage } from '../types'
+import type { EndpointFingerprint } from './endpoint-fingerprint'
+
+export interface DeliveryReceipt {
+  message: InternalMessage
+  to: EndpointFingerprint
+  from: {
+    endpointId: string
+    fingerprint: EndpointFingerprint
+  }
+}
+
+export const createDeliveryLogger = () => {
+  let logs: ReadonlyArray<DeliveryReceipt> = []
+
+  return {
+    add: (...receipts: DeliveryReceipt[]) => {
+      logs = [...logs, ...receipts]
+    },
+    remove: (message: string | DeliveryReceipt[]) => {
+      logs
+        = typeof message === 'string'
+          ? logs.filter(receipt => receipt.message.transactionId !== message)
+          : logs.filter(receipt => !message.includes(receipt))
+    },
+    entries: () => logs,
+  }
+}

--- a/src/internal/endpoint-fingerprint.ts
+++ b/src/internal/endpoint-fingerprint.ts
@@ -1,0 +1,5 @@
+import uid from 'tiny-uid'
+
+export type EndpointFingerprint = `uid::${string}`
+
+export const createFingerprint = (): EndpointFingerprint => `uid::${uid(7)}`

--- a/src/internal/persistent-port.ts
+++ b/src/internal/persistent-port.ts
@@ -1,5 +1,12 @@
 import browser from 'webextension-polyfill'
 import type { Runtime } from 'webextension-polyfill'
+import type { InternalMessage } from '../types'
+import { createFingerprint } from './endpoint-fingerprint'
+import type { QueuedMessage } from './types'
+import { encodeConnectionArgs } from './connection-args'
+import { createDeliveryLogger } from './delivery-logger'
+import type { StatusMessage } from './port-message'
+import { PortMessage } from './port-message'
 
 /**
  * Manfiest V3 extensions can have their service worker terminated at any point
@@ -9,27 +16,111 @@ import type { Runtime } from 'webextension-polyfill'
  * suspended
  */
 export const createPersistentPort = (name = '') => {
+  const fingerprint = createFingerprint()
   let port: Runtime.Port
-  const onMessageListeners = new Set<(message: any, port: Runtime.Port) => void>()
+  let undeliveredQueue: ReadonlyArray<QueuedMessage> = []
+  const pendingResponses = createDeliveryLogger()
+  const onMessageListeners = new Set<
+  (message: InternalMessage, port: Runtime.Port) => void
+  >()
+  const onFailureListeners = new Set<(message: InternalMessage) => void>()
 
-  const invokeOnMessageListeners = (message: any, port: Runtime.Port) => {
-    onMessageListeners.forEach(cb => cb(message, port))
+  const handleMessage = (msg: StatusMessage, port: Runtime.Port) => {
+    switch (msg.status) {
+      case 'undeliverable':
+        if (
+          !undeliveredQueue.some(
+            m => m.message.messageID === msg.message.messageID,
+          )
+        ) {
+          undeliveredQueue = [
+            ...undeliveredQueue,
+            {
+              message: msg.message,
+              resolvedDestination: msg.resolvedDestination,
+            },
+          ]
+        }
+
+        return
+
+      case 'deliverable':
+        undeliveredQueue = undeliveredQueue.reduce((acc, queuedMsg) => {
+          if (queuedMsg.resolvedDestination === msg.deliverableTo) {
+            PortMessage.toBackground(port, {
+              type: 'deliver',
+              message: queuedMsg.message,
+            })
+
+            return acc
+          }
+
+          return [...acc, queuedMsg]
+        }, [] as ReadonlyArray<QueuedMessage>)
+
+        return
+
+      case 'delivered':
+        if (msg.receipt.message.messageType === 'message')
+          pendingResponses.add(msg.receipt)
+
+        return
+
+      case 'incoming':
+        if (msg.message.messageType === 'reply')
+          pendingResponses.remove(msg.message.messageID)
+
+        onMessageListeners.forEach(cb => cb(msg.message, port))
+
+        return
+
+      case 'terminated': {
+        const rogueMsgs = pendingResponses
+          .entries()
+          .filter(receipt => msg.fingerprint === receipt.to)
+        pendingResponses.remove(rogueMsgs)
+        rogueMsgs.forEach(({ message }) =>
+          onFailureListeners.forEach(cb => cb(message)),
+        )
+      }
+    }
   }
 
   const connect = () => {
-    port = browser.runtime.connect({ name })
-    port.onMessage.addListener(invokeOnMessageListeners)
+    port = browser.runtime.connect({
+      name: encodeConnectionArgs({
+        endpointName: name,
+        fingerprint,
+      }),
+    })
+    port.onMessage.addListener(handleMessage)
     port.onDisconnect.addListener(connect)
+
+    PortMessage.toBackground(port, {
+      type: 'sync',
+      pendingResponses: pendingResponses.entries(),
+      pendingDeliveries: [
+        ...new Set(
+          undeliveredQueue.map(({ resolvedDestination }) => resolvedDestination),
+        ),
+      ],
+    })
   }
 
   connect()
 
   return {
-    onMessage(cb: (message: any, port: Runtime.Port) => void): void {
+    onFailure(cb: (message: InternalMessage) => void) {
+      onFailureListeners.add(cb)
+    },
+    onMessage(cb: (message: InternalMessage) => void): void {
       onMessageListeners.add(cb)
     },
     postMessage(message: any): void {
-      port.postMessage(message)
+      PortMessage.toBackground(port, {
+        type: 'deliver',
+        message,
+      })
     },
   }
 }

--- a/src/internal/port-message.ts
+++ b/src/internal/port-message.ts
@@ -1,0 +1,48 @@
+import type { Runtime } from 'webextension-polyfill'
+import type { InternalMessage } from '../types'
+import type { DeliveryReceipt } from './delivery-logger'
+import type { EndpointFingerprint } from './endpoint-fingerprint'
+
+export type StatusMessage =
+  | {
+    status: 'undeliverable'
+    message: InternalMessage
+    resolvedDestination: string
+  }
+  | {
+    status: 'deliverable'
+    deliverableTo: string
+  }
+  | {
+    status: 'delivered'
+    receipt: DeliveryReceipt
+  }
+  | {
+    status: 'incoming'
+    message: InternalMessage
+  }
+  | {
+    status: 'terminated'
+    fingerprint: EndpointFingerprint
+  }
+
+export type RequestMessage =
+  | {
+    type: 'sync'
+    pendingResponses: ReadonlyArray<DeliveryReceipt>
+    pendingDeliveries: ReadonlyArray<string>
+  }
+  | {
+    type: 'deliver'
+    message: InternalMessage
+  }
+
+export class PortMessage {
+  static toBackground(port: Runtime.Port, message: RequestMessage) {
+    return port.postMessage(message)
+  }
+
+  static toExtensionContext(port: Runtime.Port, message: StatusMessage) {
+    return port.postMessage(message)
+  }
+}

--- a/src/internal/post-message.ts
+++ b/src/internal/post-message.ts
@@ -1,16 +1,23 @@
-import type { IInternalMessage } from '../types'
+import type { InternalMessage } from '../types'
 import { getMessagePort } from './message-port'
+
+export interface EndpointWontRespondError {
+  type: 'error'
+  transactionID: string
+}
 
 export const usePostMessaging = (thisContext: 'window' | 'content-script') => {
   let allocatedNamespace: string
   let messagingEnabled = false
-  let onMessageCallback: (msg: IInternalMessage) => void
+  let onMessageCallback: (
+    msg: InternalMessage | EndpointWontRespondError
+  ) => void
   let portP: Promise<MessagePort>
 
   return {
-    enable: () => messagingEnabled = true,
-    onMessage: (cb: typeof onMessageCallback) => onMessageCallback = cb,
-    postMessage: async(msg: IInternalMessage) => {
+    enable: () => (messagingEnabled = true),
+    onMessage: (cb: typeof onMessageCallback) => (onMessageCallback = cb),
+    postMessage: async(msg: InternalMessage | EndpointWontRespondError) => {
       if (thisContext !== 'content-script' && thisContext !== 'window')
         throw new Error('Endpoint does not use postMessage')
 
@@ -26,22 +33,20 @@ export const usePostMessaging = (thisContext: 'window' | 'content-script') => {
         throw new Error('Namespace once set cannot be changed')
 
       allocatedNamespace = nsps
-      portP = getMessagePort(
-        thisContext,
-        nsps,
-        ({ data }) => onMessageCallback?.(data),
+      portP = getMessagePort(thisContext, nsps, ({ data }) =>
+        onMessageCallback?.(data),
       )
     },
   }
 }
 
 function ensureNamespaceSet(namespace: string) {
-  if (typeof namespace !== 'string' || namespace.length === 0) {
+  if (typeof namespace !== 'string' || namespace.trim().length === 0) {
     throw new Error(
-      'webext-bridge uses window.postMessage to talk with other "window"(s), for message routing and stuff,'
-      + 'which is global/conflicting operation in case there are other scripts using webext-bridge. '
-      + 'Call Bridge#setNamespace(nsps) to isolate your app. Example: setNamespace(\'com.facebook.react-devtools\'). '
-      + 'Make sure to use same namespace across all your scripts whereever window.postMessage is likely to be used`',
+      'webext-bridge uses window.postMessage to talk with other "window"(s) for message routing'
+        + 'which is global/conflicting operation in case there are other scripts using webext-bridge. '
+        + 'Call Bridge#setNamespace(nsps) to isolate your app. Example: setNamespace(\'com.facebook.react-devtools\'). '
+        + 'Make sure to use same namespace across all your scripts whereever window.postMessage is likely to be used`',
     )
   }
 }

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,0 +1,6 @@
+import type { InternalMessage } from '../types'
+
+export interface QueuedMessage {
+  resolvedDestination: string
+  message: InternalMessage
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,12 @@
 import type { JsonValue, Jsonify } from 'type-fest'
 
-export type RuntimeContext = 'devtools' | 'background' | 'popup' | 'options' | 'content-script' | 'window'
+export type RuntimeContext =
+  | 'devtools'
+  | 'background'
+  | 'popup'
+  | 'options'
+  | 'content-script'
+  | 'window'
 
 export interface Endpoint {
   context: RuntimeContext
@@ -8,16 +14,18 @@ export interface Endpoint {
   frameId?: number
 }
 
-export interface IBridgeMessage<T extends JsonValue> {
+export interface BridgeMessage<T extends JsonValue> {
   sender: Endpoint
   id: string
   data: T
   timestamp: number
 }
 
-export type OnMessageCallback<T extends JsonValue, R = void | JsonValue> = (message: IBridgeMessage<T>) => R | Promise<R>
+export type OnMessageCallback<T extends JsonValue, R = void | JsonValue> = (
+  message: BridgeMessage<T>
+) => R | Promise<R>
 
-export interface IInternalMessage {
+export interface InternalMessage {
   origin: Endpoint
   destination: Endpoint
   transactionId: string
@@ -62,7 +70,9 @@ export interface ProtocolMap {
   // bar: ProtocolWithReturn<string, number>
 }
 
-export type DataTypeKey = keyof ProtocolMap extends never ? string : keyof ProtocolMap
+export type DataTypeKey = keyof ProtocolMap extends never
+  ? string
+  : keyof ProtocolMap
 
 export type GetDataType<
   K extends DataTypeKey,

--- a/src/window.ts
+++ b/src/window.ts
@@ -4,12 +4,15 @@ import { createStreamWirings } from './internal/stream'
 
 const win = usePostMessaging('window')
 
-const endpointRuntime = createEndpointRuntime(
-  'window',
-  message => win.postMessage(message),
+const endpointRuntime = createEndpointRuntime('window', message =>
+  win.postMessage(message),
 )
 
-win.onMessage(endpointRuntime.handleMessage)
+win.onMessage((msg) => {
+  if ('type' in msg && 'transactionID' in msg)
+    endpointRuntime.endTransaction(msg.transactionID)
+  else endpointRuntime.handleMessage(msg)
+})
 
 export function setNamespace(nsps: string): void {
   win.setNamespace(nsps)
@@ -17,4 +20,5 @@ export function setNamespace(nsps: string): void {
 }
 
 export const { sendMessage, onMessage } = endpointRuntime
-export const { openStream, onOpenStreamChannel } = createStreamWirings(endpointRuntime)
+export const { openStream, onOpenStreamChannel }
+  = createStreamWirings(endpointRuntime)


### PR DESCRIPTION
Fixes https://github.com/zikaari/webext-bridge/issues/23
    
Each message sent now relies on delivery receipts to ensure they were
    indeed delivered AND to expect the destination's response. In case the
    destination disconnects before it could have responded, sendMessage
    Promise will be rejected with an 'Transaction ended before it could
    complete'.
    
Queued messages are also no longer tracked in the background page, since
    it is ephemeral in manifest v3 extensions. Each endpoint now keeps track
    of its queued messages, and responses it is waiting on, in its on own
    runtime. This new strategy also acts as a safe-guard against
    destinations receiving stale messages from endpoints that no longer
    exist __(previsouly this could happen as there was no message invalidation
    logic for when the sender disconneted)__.
    
The role of background page is no longer to maintain the "state" of the
    system, but to just act as a relay and to inform the relevant endpoints
    when the destination they are transacting with have been disconnected.